### PR TITLE
fixed text-color in bubble, changed ugly grey background to normal

### DIFF
--- a/src/components/MessageItem.vue
+++ b/src/components/MessageItem.vue
@@ -69,7 +69,7 @@ onBeforeUnmount(() => {
 
 function getColorByUserId(userId: string): string {
     if (isMe) return "#446df1";
-    return "#666161";
+    return "#303030";
 }
 
 const bubbleColor = computed(() => {
@@ -135,11 +135,10 @@ function isSingleEmojiOnly(message: IArgonMessage): boolean {
     line-height: 1.4;
     word-break: break-word;
     white-space: pre-wrap;
-    background-color: #0088cc;
+    background-color: #00;
 }
 
 .incoming .bubble {
-    color: black;
     background-color: #666161;
     border-top-left-radius: 4px;
 }

--- a/src/components/MessageItem.vue
+++ b/src/components/MessageItem.vue
@@ -135,7 +135,7 @@ function isSingleEmojiOnly(message: IArgonMessage): boolean {
     line-height: 1.4;
     word-break: break-word;
     white-space: pre-wrap;
-    background-color: #00;
+    background-color: #0088cc;
 }
 
 .incoming .bubble {


### PR DESCRIPTION
Now the messages at least readable

<img width="462" alt="image" src="https://github.com/user-attachments/assets/5410c947-2a90-4d10-9bfd-b87486d83667" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
	- Updated the color scheme for messages from others to enhance visual contrast.
	- Removed a fixed text color for incoming message bubbles, allowing for a cleaner, default look.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->